### PR TITLE
Midi-macros.js: static async deleteItems function issue with [itemArray]

### DIFF
--- a/scripts/MidiSRD-macros.js
+++ b/scripts/MidiSRD-macros.js
@@ -47,7 +47,7 @@ class MidiMacros {
     static async deleteItems(flagName, actor) {
         let items = actor.items.filter(i => i.data.flags["midi-srd"]?.[flagName] === actor.id)
         let itemArray = items.map(function (w) { return w.data._id })
-        if (itemArray.length > 0) await actor.deleteEmbeddedDocuments("Item", [itemArray]);
+        if (itemArray.length > 0) await actor.deleteEmbeddedDocuments("Item", itemArray);
     }
 
     /**


### PR DESCRIPTION
itemArray is already a map of the items IDs.
Proposed change `await actor.deleteEmbeddedDocuments("Item", [itemArray]); ` to

`await actor.deleteEmbeddedDocuments("Item", itemArray);`